### PR TITLE
Prevent empty lastmod if not given

### DIFF
--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -435,7 +435,9 @@ class SitemapGenerator
                 );
 
                 if ($this->urls[$urlCounter]->getSize() > 1) {
-                    $row->addChild(self::ATTR_NAME_LASTMOD, $this->urls[$urlCounter][self::ATTR_KEY_LASTMOD]);
+                    if (isset($this->urls[$urlCounter][self::ATTR_KEY_LASTMOD])) {
+                        $row->addChild(self::ATTR_NAME_LASTMOD, $this->urls[$urlCounter][self::ATTR_KEY_LASTMOD]);
+                    }
                 }
                 if ($this->urls[$urlCounter]->getSize() > 2) {
                     $row->addChild(self::ATTR_NAME_CHANGEFREQ, $this->urls[$urlCounter][self::ATTR_KEY_CHANGEFREQ]);


### PR DESCRIPTION
This condition prevent empty lastmod property in generated XML if no date are given. Google Search Console give an error if this property is defined but empty.