### PR TITLE
Creating sitemap index separately

### DIFF
--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -696,7 +696,7 @@ class SitemapGenerator
      */
     public function writeSitemapIndex(): SitemapGenerator
     {
-        if (count($this->sitemapIndex) === 0) {
+        if (count($this->urls) === 0) {
             throw new BadMethodCallException("To write sitemap index, call createSitemapIndex function first.");
         }
 

--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -597,10 +597,12 @@ class SitemapGenerator
         $counter = 0;
         foreach ($this->urls as $url) {
 
-            $row = $sitemapXml->addChild('sitemap');
-            $row->addChild(self::ATTR_NAME_LOC, $this->baseURL . "/" . $this->appendGzPostfixIfEnabled(htmlentities($url[0])));
-            $row->addChild(self::ATTR_NAME_LASTMOD, date('c'));
-            $counter++;
+            if(!empty($url)) {
+                $row = $sitemapXml->addChild('sitemap');
+                $row->addChild(self::ATTR_NAME_LOC, $this->baseURL . "/" . $this->appendGzPostfixIfEnabled(htmlentities($url[0])));
+                $row->addChild(self::ATTR_NAME_LASTMOD, date('c'));
+                $counter++;
+            }
         }
 
         $this->sitemapFullURL = $this->baseURL . "/" . $this->appendGzPostfixIfEnabled($this->sitemapIndexFileName);


### PR DESCRIPTION
There is a problem with memory if you have many URL's (I need about 2M). 

So I add possibility to write sitemap index separately - for saving memory, you can create index one by one (so only one object is in the memory) and then you create sitemap index.

Add sitemap index to generator:
`$generator->addSitemap('sitemap1.xml');`

Create and write sitemap index:
`$generator->createSitemapIndex();`

As both using same internal object of urls, I added basic protection for mixing. Once addSitemap function is used, addUrl cannot be used and vice versa.

I did not have time to explore the saving of meta information in deep, so the datetime stamp is now created from current time, but it will be easy to you to fixed it.

Also as some code blocks are now duplicated, the best way will be refactoring to one separate functions, but as I said, I have only a few minutes during one big project development. :)

Hoping this will be usefull.
