### PR TITLE
Remove function call htmlspecialchars from XMLWriter

### DIFF
--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -416,7 +416,7 @@ class SitemapGenerator
     private function writeSitemapUrl($loc, $lastModified, $changeFrequency, $priority, $alternates, $extensions)
     {
         $this->xmlWriter->startElement('url');
-        $this->xmlWriter->writeElement('loc', htmlspecialchars($loc, ENT_QUOTES));
+        $this->xmlWriter->writeElement('loc', $loc);
 
         if ($lastModified !== null) {
             $this->xmlWriter->writeElement('lastmod', $lastModified->format(DateTime::ATOM));
@@ -584,7 +584,7 @@ class SitemapGenerator
     private function writeSitemapIndexUrl($url)
     {
         $this->xmlWriter->startElement('sitemap');
-        $this->xmlWriter->writeElement('loc', htmlspecialchars($url, ENT_QUOTES));
+        $this->xmlWriter->writeElement('loc', $url);
         $this->xmlWriter->writeElement('lastmod', date('c'));
         $this->xmlWriter->endElement(); // sitemap
     }

--- a/test/Feature/SitemapGeneratorTest.php
+++ b/test/Feature/SitemapGeneratorTest.php
@@ -807,4 +807,28 @@ class SitemapGeneratorTest extends TestCase
         $generator->finalize();
     }
 
+    public function testUrlsWithHtmlSpecialChars()
+    {
+        $siteUrl = 'https://example.com';
+        $outputDir = '/tmp';
+
+        $generator = new SitemapGenerator($siteUrl, $outputDir);
+
+        $generator->addURL('/index.php?param1=p1&param2=p2', null, null, null, null);
+        $generator->addURL('/index.php?param1="p 1"&param2="p 2"', null, null, null, null);
+
+        $generator->flush();
+        $generator->finalize();
+
+        $sitemapFilepath = $outputDir . '/sitemap.xml';
+        $this->assertFileExists($sitemapFilepath);
+
+        $sitemap = new SimpleXMLElement(file_get_contents($sitemapFilepath));
+        $url1 = $sitemap->children()->url[0];
+        $url2 = $sitemap->children()->url[1];
+
+        $this->assertEquals('https://example.com/index.php?param1=p1&param2=p2', $url1->loc);
+        $this->assertEquals('https://example.com/index.php?param1="p 1"&param2="p 2"', $url2->loc);
+    }
+
 }


### PR DESCRIPTION
Hi,

The function htmlspecialchars($loc, ENT_QUOTES) no need be call because xmlWriter already convert special characters and was small bug with & (ampersand ).

For example when add URL with `&` was convert to `&amp;amp;`

Examples:
`https://example.com/index.php?param1=1&param2=2&param3=3` => `https://example.com/index.php?param1=1&amp;amp;param2=2&amp;amp;param3=3`

![image](https://user-images.githubusercontent.com/14443/185381570-8afdb3f4-1efb-4d1a-a375-13eae3f52073.png)
![image](https://user-images.githubusercontent.com/14443/185381694-77e39b57-2276-4109-89fb-3f78f1bd931b.png)
![image](https://user-images.githubusercontent.com/14443/185382267-0de2de5f-bf38-440f-9597-fba81515f696.png)


