### PR TITLE
Update GoogleImageExtension.php

### DIFF
--- a/src/Extensions/GoogleImageExtension.php
+++ b/src/Extensions/GoogleImageExtension.php
@@ -13,6 +13,22 @@ class GoogleImageExtension
 
     public static function writeImageTag(XMLWriter $xmlWriter, array $extFields)
     {
+        // If an assoc array, process it directly. If a numeric array, use foreach. Supported by PHP versions even older than 8.
+        if(is_array($extFields) && array_keys($extFields) !== range(0, count($extFields) - 1))
+        {
+            self::writeImageTagSingle($xmlWriter, $extFields);
+        }
+        else
+        {
+            foreach ($extFields as $extFieldSingle)
+            {
+                self::writeImageTagSingle($xmlWriter, $extFieldSingle);
+            }
+        }
+    }
+
+    public static function writeImageTagSingle(XMLWriter $xmlWriter, array $extFields)
+    {
         self::validate($extFields);
 
         $xmlWriter->startElement('image:image');
@@ -38,6 +54,22 @@ class GoogleImageExtension
     }
 
     public static function validate($extFields)
+    {
+        // If an assoc array, process it directly. If a numeric array, use foreach. Supported by PHP versions even older than 8.
+        if(is_array($extFields) && array_keys($extFields) !== range(0, count($extFields) - 1))
+        {
+            self::validateSingle($extFields);
+        }
+        else
+        {
+            foreach ($extFields as $extFieldSingle)
+            {
+                self::validateSingle($extFieldSingle);
+            }
+        }
+    }
+
+    public static function validateSingle($extFields)
     {
         $extFieldNames = array_keys($extFields);
 


### PR DESCRIPTION
Added the support for multiple image:loc infos per page.

To use only one image for a page:
```
// // add image
$extensions = [
    'google_image' => ['loc' => 'https://www.example.com/thumbs/1.jpg']
];
```

To use multiple images for a page:
```
// add multiple images
$extensions = [
    'google_image' =>   [
                            ['loc' => 'https://www.example.com/thumbs/1.jpg'],
                            ['loc' => 'https://www.example.com/thumbs/2.jpg'],
                            ['loc' => 'https://www.example.com/thumbs/3.jpg']
                        ]
        
];
```

The code can be shortened by array_is_list() function. Because it is not supported by PHP<=7, we better use the classic way to determine if the data given is an assoc or a numeric array.
