### PR TITLE
Adds base sitemap URL configuration parameter

### DIFF
--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -94,6 +94,13 @@ class SitemapGenerator
      */
     private $baseURL;
     /**
+     * URL to sitemap file(s).
+     * Script will use it to reference sitemap files in robots.txt and sitemap index.
+     * @var string
+     * @access private
+     */
+    private $sitemapBaseURL;
+    /**
      * Base path. Relative to script location.
      * Use this if Your sitemap and robots files should be stored in other
      * directory then script.
@@ -212,6 +219,7 @@ class SitemapGenerator
     public function __construct(string $baseURL, string $basePath = "", FileSystem $fs = null, Runtime $runtime = null)
     {
         $this->baseURL = rtrim($baseURL, '/');
+        $this->sitemapBaseURL = $this->baseURL;
 
         if ($fs === null) {
             $this->fs = new FileSystem();
@@ -334,6 +342,12 @@ class SitemapGenerator
     public function isCompressionEnabled(): bool
     {
         return $this->isCompressionEnabled;
+    }
+
+    public function setSitemapBaseURL(string $sitemapBaseURL): SitemapGenerator
+    {
+        $this->sitemapBaseURL = rtrim($sitemapBaseURL, '/');
+        return $this;
     }
 
     public function validate(
@@ -550,7 +564,7 @@ class SitemapGenerator
                 $this->fs->rename($this->flushedSitemaps[0], $targetSitemapFilepath);
             }
             $this->generatedFiles['sitemaps_location'] = [$targetSitemapFilepath];
-            $this->generatedFiles['sitemaps_index_url'] = $this->baseURL . '/' . $targetSitemapFilename;
+            $this->generatedFiles['sitemaps_index_url'] = $this->sitemapBaseURL . '/' . $targetSitemapFilename;
         } else if (count($this->flushedSitemaps) > 1) {
             $ext = '.' . pathinfo($this->sitemapFileName, PATHINFO_EXTENSION);
             $targetExt = $ext;
@@ -570,7 +584,7 @@ class SitemapGenerator
                 } else {
                     $this->fs->rename($flushedSitemap, $targetSitemapFilepath);
                 }
-                $sitemapsUrls[] = htmlspecialchars($this->baseURL . '/' . $targetSitemapFilename, ENT_QUOTES);
+                $sitemapsUrls[] = htmlspecialchars($this->sitemapBaseURL . '/' . $targetSitemapFilename, ENT_QUOTES);
                 $targetSitemapFilepaths[] = $targetSitemapFilepath;
             }
 
@@ -578,7 +592,7 @@ class SitemapGenerator
             $this->createSitemapIndex($sitemapsUrls, $targetSitemapIndexFilepath);
             $this->generatedFiles['sitemaps_location'] = $targetSitemapFilepaths;
             $this->generatedFiles['sitemaps_index_location'] = $targetSitemapIndexFilepath;
-            $this->generatedFiles['sitemaps_index_url'] = $this->baseURL . '/' . $this->sitemapIndexFileName;
+            $this->generatedFiles['sitemaps_index_url'] = $this->sitemapBaseURL . '/' . $this->sitemapIndexFileName;
         } else {
             throw new RuntimeException('failed to finalize, please add urls and flush first');
         }

--- a/test/Feature/SitemapGeneratorTest.php
+++ b/test/Feature/SitemapGeneratorTest.php
@@ -475,6 +475,107 @@ class SitemapGeneratorTest extends TestCase
         $this->assertEquals('https://example.com/sitemap-index.xml', $generatedFiles['sitemaps_index_url']);
     }
 
+    public function testMultipleSitemapsWithSitemapBaseUrl()
+    {
+        $siteUrl = 'https://example.com';
+        $outputDir = $this->saveDir;
+        // Add trailing slash to test that it is removed automatically.
+        $sitemapBaseURL = 'https://example.com/sitemaps/';
+
+        $generator = new SitemapGenerator($siteUrl, $outputDir);
+        $generator->setMaxUrlsPerSitemap(1);
+        $generator->setSitemapBaseURL($sitemapBaseURL);
+        $alternates = [
+            ['hreflang' => 'de', 'href' => "http://www.example.com/de"],
+            ['hreflang' => 'fr', 'href' => "http://www.example.com/fr"],
+        ];
+
+        $datetimeStr = '2020-12-29T08:46:55+00:00';
+        $lastmod = new DateTime('2020-12-29T08:46:55+00:00');
+
+        for ($i = 0; $i < 2; $i++) {
+            $generator->addURL("/path/to/page-$i/", $lastmod, 'always', 0.5, $alternates);
+        }
+
+        $generator->flush();
+        $generator->finalize();
+
+        $sitemapIndexFilepath = $this->saveDir . DIRECTORY_SEPARATOR . 'sitemap-index.xml';
+        $this->assertFileExists($sitemapIndexFilepath);
+        $sitemapIndex = new SimpleXMLElement(file_get_contents($sitemapIndexFilepath));
+        $this->assertEquals('sitemapindex', $sitemapIndex->getName());
+        $this->assertEquals(2, $sitemapIndex->count());
+        $ns = $sitemapIndex->getNamespaces();
+        $this->assertEquals('http://www.w3.org/2001/XMLSchema-instance', $ns['xsi']);
+        $this->assertEquals('http://www.sitemaps.org/schemas/sitemap/0.9', array_shift($ns));
+        $this->assertEquals('https://example.com/sitemaps/sitemap1.xml', $sitemapIndex->sitemap[0]->loc);
+        $this->assertNotNull($sitemapIndex->sitemap[0]->lastmod);
+        $this->assertEquals('https://example.com/sitemaps/sitemap2.xml', $sitemapIndex->sitemap[1]->loc);
+        $this->assertNotNull($sitemapIndex->sitemap[1]->lastmod);
+        unlink($sitemapIndexFilepath);
+
+        $sitemapFilepath1 = $this->saveDir . DIRECTORY_SEPARATOR . 'sitemap1.xml';
+        $this->assertFileExists($sitemapFilepath1);
+
+        $sitemapXHTML = new SimpleXMLElement(file_get_contents($sitemapFilepath1), 0, false, 'xhtml', true);
+        foreach ($sitemapXHTML->children() as $url) {
+            $links = $url->children('xhtml', true)->link;
+            $this->assertEquals('alternate', $links[0]->attributes()['rel']);
+            $this->assertEquals('de', $links[0]->attributes()['hreflang']);
+            $this->assertEquals('http://www.example.com/de', $links[0]->attributes()['href']);
+            $this->assertEquals('alternate', $links[1]->attributes()['rel']);
+            $this->assertEquals('fr', $links[1]->attributes()['hreflang']);
+            $this->assertEquals('http://www.example.com/fr', $links[1]->attributes()['href']);
+        }
+
+        $sitemap1 = new SimpleXMLElement(file_get_contents($sitemapFilepath1));
+        $this->assertEquals('urlset', $sitemap1->getName());
+        $this->assertEquals(1, $sitemap1->count());
+        $ns = $sitemap1->getNamespaces();
+        $this->assertEquals('http://www.w3.org/2001/XMLSchema-instance', $ns['xsi']);
+        $this->assertEquals('http://www.sitemaps.org/schemas/sitemap/0.9', array_shift($ns));
+        $this->assertEquals('https://example.com/path/to/page-0/', $sitemap1->url[0]->loc);
+        $this->assertEquals($datetimeStr, $sitemap1->url[0]->lastmod);
+        $this->assertEquals('always', $sitemap1->url[0]->changefreq);
+        $this->assertEquals('0.5', $sitemap1->url[0]->priority);
+        unlink($sitemapFilepath1);
+
+        $sitemapFilepath2 = $this->saveDir . DIRECTORY_SEPARATOR . 'sitemap2.xml';
+        $this->assertFileExists($sitemapFilepath2);
+
+        $sitemapXHTML = new SimpleXMLElement(file_get_contents($sitemapFilepath2), 0, false, 'xhtml', true);
+        foreach ($sitemapXHTML->children() as $url) {
+            $links = $url->children('xhtml', true)->link;
+            $this->assertEquals('alternate', $links[0]->attributes()['rel']);
+            $this->assertEquals('de', $links[0]->attributes()['hreflang']);
+            $this->assertEquals('http://www.example.com/de', $links[0]->attributes()['href']);
+            $this->assertEquals('alternate', $links[1]->attributes()['rel']);
+            $this->assertEquals('fr', $links[1]->attributes()['hreflang']);
+            $this->assertEquals('http://www.example.com/fr', $links[1]->attributes()['href']);
+        }
+
+        $sitemap2 = new SimpleXMLElement(file_get_contents($sitemapFilepath2));
+        $this->assertEquals('urlset', $sitemap2->getName());
+        $this->assertEquals(1, $sitemap2->count());
+        $ns = $sitemap2->getNamespaces();
+        $this->assertEquals('http://www.w3.org/2001/XMLSchema-instance', $ns['xsi']);
+        $this->assertEquals('http://www.sitemaps.org/schemas/sitemap/0.9', array_shift($ns));
+        $this->assertEquals('https://example.com/path/to/page-1/', $sitemap2->url[0]->loc);
+        $this->assertEquals($datetimeStr, $sitemap2->url[0]->lastmod);
+        $this->assertEquals('always', $sitemap2->url[0]->changefreq);
+        $this->assertEquals('0.5', $sitemap2->url[0]->priority);
+        unlink($sitemapFilepath2);
+
+        $generatedFiles = $generator->getGeneratedFiles();
+        $this->assertCount(3, $generatedFiles);
+        $this->assertNotEmpty($generatedFiles['sitemaps_location']);
+        $this->assertCount(2, $generatedFiles['sitemaps_location']);
+        $this->assertEquals($this->saveDir . DIRECTORY_SEPARATOR . 'sitemap1.xml', $generatedFiles['sitemaps_location'][0]);
+        $this->assertEquals($this->saveDir . DIRECTORY_SEPARATOR . 'sitemap2.xml', $generatedFiles['sitemaps_location'][1]);
+        $this->assertEquals($this->saveDir . DIRECTORY_SEPARATOR . 'sitemap-index.xml', $generatedFiles['sitemaps_index_location']);
+        $this->assertEquals('https://example.com/sitemaps/sitemap-index.xml', $generatedFiles['sitemaps_index_url']);
+    }
+
     public function testMultipleSitemapsWithCustomSitemapIndexName()
     {
         $siteUrl = 'https://example.com';


### PR DESCRIPTION
This PR provides the functionality described in #24 by adding an optional `sitemapBaseURL` property. The default value is that of `baseURL`. Since it is probably more common to have the sitemap directly in the base URL, the constructor signature is not changed and the value set separately via a setter.

Would be happy to see this feature be introduced. Looking forward to hearing from you.