### PR TITLE
Add stylesheet to index as well as sitemap

### DIFF
--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -661,6 +661,10 @@ class SitemapGenerator
     protected function writeSitemapIndexStart(): void
     {
         $this->xmlWriter->startDocument("1.0", "UTF-8");
+        if ($this->sitemapStylesheetLink != "") {
+            $this->xmlWriter->writePi('xml-stylesheet',
+                sprintf('type="text/xsl" href="%s"', $this->sitemapStylesheetLink));
+        }
         $this->xmlWriter->writeComment(sprintf('generator-class="%s"', get_class($this)));
         $this->xmlWriter->writeComment(sprintf('generator-version="%s"', $this->classVersion));
         $this->xmlWriter->writeComment(sprintf('generated-on="%s"', date('c')));


### PR DESCRIPTION
If we've applied a stylesheet to the sitemap itself, not sure it makes an sense "not" so apply it to the index, unless there were a specific feature to add an index stylesheet - which it doesn't look like there is.