### PR TITLE
fix: explicitly declare nullable types for parameters defaulting to null

### DIFF
--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -370,10 +370,10 @@ class SitemapGenerator
      * @throws InvalidArgumentException
      */
     public function validate(
-        string   $path,
-        string   $changeFrequency = null,
-        float    $priority = null,
-        array    $extensions = []): void
+        string    $path,
+        ?string   $changeFrequency = null,
+        ?float    $priority = null,
+        array     $extensions = []): void
     {
         if (!(1 <= mb_strlen($path) && mb_strlen($path) <= self::MAX_URL_LEN)) {
             throw new InvalidArgumentException(
@@ -416,12 +416,12 @@ class SitemapGenerator
      * @throws InvalidArgumentException
      */
     public function addURL(
-        string   $path,
-        DateTime $lastModified = null,
-        string   $changeFrequency = null,
-        float    $priority = null,
-        array    $alternates = null,
-        array    $extensions = []
+        string    $path,
+        ?DateTime $lastModified = null,
+        ?string   $changeFrequency = null,
+        ?float    $priority = null,
+        ?array    $alternates = null,
+        array     $extensions = []
     ): SitemapGenerator
     {
         $this->validate($path, $changeFrequency, $priority, $extensions);
@@ -495,12 +495,12 @@ class SitemapGenerator
      * @throws UnexpectedValueException
      */
     private function writeSitemapUrl(
-        string   $loc,
-        DateTime $lastModified = null,
-        string   $changeFrequency = null,
-        float    $priority = null,
-        array    $alternates = null,
-        array    $extensions = []
+        string    $loc,
+        DateTime  $lastModified = null,
+        ?string   $changeFrequency = null,
+        ?float    $priority = null,
+        ?array    $alternates = null,
+        array     $extensions = []
     ): void {
         $this->xmlWriter->startElement('url');
         $this->xmlWriter->writeElement('loc', $this->encodeEscapeURL($loc));

--- a/src/SitemapGenerator.php
+++ b/src/SitemapGenerator.php
@@ -496,7 +496,7 @@ class SitemapGenerator
      */
     private function writeSitemapUrl(
         string    $loc,
-        DateTime  $lastModified = null,
+        ?DateTime  $lastModified = null,
         ?string   $changeFrequency = null,
         ?float    $priority = null,
         ?array    $alternates = null,


### PR DESCRIPTION
This PR resolves a PHP deprecation warning regarding implicit nullable parameters. In recent PHP versions, implicitly marking a parameter as nullable by giving it a default value of `null` is deprecated. Parameters that accept `null` must now be explicitly declared as nullable.

> Deprecated: Icamys\SitemapGenerator\SitemapGenerator::writeSitemapUrl(): Implicitly marking parameter $lastModified as nullable is deprecated, the explicit nullable type must be used instead